### PR TITLE
Enable keyboard shortcut and its configuration

### DIFF
--- a/src/anki_ipa/__init__.py
+++ b/src/anki_ipa/__init__.py
@@ -111,8 +111,16 @@ def on_setup_buttons(buttons: List[str], editor: Editor) -> List[str]:
     :param editor: card editor object
     :return: updated list of buttons
     """
+    shortcut_keys = CONFIG.get("KEYBOARD_SHORTCUT", "Ctrl+Shift+Z")
+
     # add HTML button
-    button = editor.addButton(ICON_PATH, "IPA", paste_ipa)
+    button = editor.addButton(
+        ICON_PATH,
+        "IPA",
+        paste_ipa,
+        keys=shortcut_keys,
+        tip=f"IPA transcription ({shortcut_keys})"
+    )
     buttons.append(button)
 
     # create list of language options

--- a/src/anki_ipa/config.json
+++ b/src/anki_ipa/config.json
@@ -1,4 +1,5 @@
 {
     "WORD_FIELD": "Front",
-    "IPA_FIELD": "IPA"
+    "IPA_FIELD": "IPA",
+    "KEYBOARD_SHORTCUT": "Ctrl+Shift+Z"
 }


### PR DESCRIPTION
Closes #55 

This PR allows using the editor button with a keyboard shortcut. This shortcut can be changed in the settings as they work now with IPA and WORD fields.

Also, I have added a tip to make the user know what shortcut is being used.