### PR TITLE
[#47] fix: wrong english output for 'out' word

### DIFF
--- a/src/anki_ipa/parse_ipa_transcription.py
+++ b/src/anki_ipa/parse_ipa_transcription.py
@@ -30,7 +30,7 @@ def british(word: str) -> str:
             p = re.compile("{{a\|RP}} {{IPA\|en\|([^}]+)}}")
             m = p.search(wikitext)
         if m is None: 
-            p = re.compile("{{IPA\|en\|([^}]+)\|([^}]+)}}")
+            p = re.compile(", {{IPA\|en\|([^}]+)\|([^}]+)}}")
             m = p.search(wikitext)
         if m is None: 
             p = re.compile("{{IPA\|en\|([^}]+)}}")
@@ -56,7 +56,7 @@ def american(word: str) -> str:
             p = re.compile("{{a\|GenAm}}.*?{{IPA\|en\|([^}]+)}}")
             m = p.search(wikitext)
         if m is None:
-            p = re.compile("{{IPA\|en\|([^}]+)\|([^}]+)}}")
+            p = re.compile(", {{IPA\|en\|([^}]+)\|([^}]+)}}")
             m = p.search(wikitext)
         if m is None:
             p = re.compile("{{IPA\|en\|([^}]+)}}")

--- a/src/anki_ipa/parse_ipa_transcription.py
+++ b/src/anki_ipa/parse_ipa_transcription.py
@@ -30,10 +30,10 @@ def british(word: str) -> str:
             p = re.compile("{{a\|RP}} {{IPA\|en\|([^}]+)}}")
             m = p.search(wikitext)
         if m is None: 
-            p = re.compile(", {{IPA\|en\|([^}]+)\|([^}]+)}}")
+            p = re.compile("{{IPA\|en\|([^}]+)}}")
             m = p.search(wikitext)
         if m is None: 
-            p = re.compile("{{IPA\|en\|([^}]+)}}")
+            p = re.compile("{{IPA\|en\|([^}]+)\|([^}]+)}}")
             m = p.search(wikitext)
             
         ipa = m.group(1)
@@ -56,10 +56,10 @@ def american(word: str) -> str:
             p = re.compile("{{a\|GenAm}}.*?{{IPA\|en\|([^}]+)}}")
             m = p.search(wikitext)
         if m is None:
-            p = re.compile(", {{IPA\|en\|([^}]+)\|([^}]+)}}")
+            p = re.compile("{{IPA\|en\|([^}]+)}}")
             m = p.search(wikitext)
         if m is None:
-            p = re.compile("{{IPA\|en\|([^}]+)}}")
+            p = re.compile("{{IPA\|en\|([^}]+)\|([^}]+)}}")
             m = p.search(wikitext)
 
         ipa = m.group(1)

--- a/src/anki_ipa/test_parse_ipa_transcription.py
+++ b/src/anki_ipa/test_parse_ipa_transcription.py
@@ -26,6 +26,7 @@ class TestParseIpa(unittest.TestCase):
         self.assertEqual(parse_ipa.british("back"), "bæk|bæk|bak|-k̚")
         # {{a|RP}} {{IPA|en|/ɹɪˈɡɑːd/}}
         self.assertEqual(parse_ipa.british("regard"), "ɹɪˈɡɑːd")
+        self.assertEqual(parse_ipa.british("out", "aʊt"))
 
     def test_american(self):
         # * {{a|GA}} {{IPA|en|/ˈt͡ʃɑɹ.koʊl/}}
@@ -41,6 +42,7 @@ class TestParseIpa(unittest.TestCase):
         self.assertEqual(parse_ipa.american("back"), "bæk|bæk|bak|-k̚")
         # {{a|GenAm}} {{IPA|en|/ɹɪˈɡɑɹd/}}
         self.assertEqual(parse_ipa.american("regard"), "ɹɪˈɡɑɹd")
+        self.assertEqual(parse_ipa.american("out", "aʊt"))
 
     def test_russian(self):
         self.assertEqual(parse_ipa.russian("спасибо"), "spɐˈsʲibə")

--- a/src/anki_ipa/test_parse_ipa_transcription.py
+++ b/src/anki_ipa/test_parse_ipa_transcription.py
@@ -21,12 +21,12 @@ class TestParseIpa(unittest.TestCase):
         self.assertEqual(parse_ipa.british("box"), "bɒks")
         # * {{a|UK}} {{IPA|en|/bɜːst/}}
         self.assertEqual(parse_ipa.british("burst"), "bɜːst")
-        self.assertEqual(parse_ipa.british("hill"), "hɪl")
+        self.assertEqual(parse_ipa.british("hill"), "hɪl|hɪɫ")
         # {{a|RP|GA}} {{IPA|en|/bæk/|[bæk]|[bak]|[-k̚]|[-ˀk]}}
-        self.assertEqual(parse_ipa.british("back"), "bæk|bæk|bak|-k̚")
+        self.assertEqual(parse_ipa.british("back"), "bæk|bæk|bak|-k̚|-ˀk")
         # {{a|RP}} {{IPA|en|/ɹɪˈɡɑːd/}}
         self.assertEqual(parse_ipa.british("regard"), "ɹɪˈɡɑːd")
-        self.assertEqual(parse_ipa.british("out", "aʊt"))
+        self.assertEqual(parse_ipa.british("out"), "aʊt")
 
     def test_american(self):
         # * {{a|GA}} {{IPA|en|/ˈt͡ʃɑɹ.koʊl/}}
@@ -37,12 +37,12 @@ class TestParseIpa(unittest.TestCase):
         # * {{a|US}} {{IPA|en|/bɝst/}}
         self.assertEqual(parse_ipa.american("burst"), "bɝst")
         # {{enPR|hĭl}}, {{IPA|en|/hɪl/|[hɪɫ]}}
-        self.assertEqual(parse_ipa.american("hill"), "hɪl")
+        self.assertEqual(parse_ipa.american("hill"), "hɪl|hɪɫ")
         # {{a|RP|GA}} {{IPA|en|/bæk/|[bæk]|[bak]|[-k̚]|[-ˀk]}}
-        self.assertEqual(parse_ipa.american("back"), "bæk|bæk|bak|-k̚")
+        self.assertEqual(parse_ipa.american("back"), "bæk|bæk|bak|-k̚|-ˀk")
         # {{a|GenAm}} {{IPA|en|/ɹɪˈɡɑɹd/}}
         self.assertEqual(parse_ipa.american("regard"), "ɹɪˈɡɑɹd")
-        self.assertEqual(parse_ipa.american("out", "aʊt"))
+        self.assertEqual(parse_ipa.american("out"), "aʊt")
 
     def test_russian(self):
         self.assertEqual(parse_ipa.russian("спасибо"), "spɐˈsʲibə")


### PR DESCRIPTION
## Changes

- Add test for _out_ word for eng_a and eng_b
- Order on translate regex compile
- Fix tests for hill and back  for eng_a and eng_b

## Screenshots

![image](https://user-images.githubusercontent.com/62189355/197364412-24dfdf4a-33cf-4138-ba96-c52b73fadbc3.png)


## Notes

https://en.m.wiktionary.org/wiki/back
https://en.m.wiktionary.org/wiki/hill
https://en.m.wiktionary.org/wiki/out