### PR TITLE
Fix for some languages IPA not populating

### DIFF
--- a/src/anki_ipa/__init__.py
+++ b/src/anki_ipa/__init__.py
@@ -57,7 +57,7 @@ def paste_ipa(editor: Editor) -> None:
 
     # parse IPA transcription for every word in word list
     try:
-        ipa = parse_ipa_transcription.transcript(words=words, language=lang_alias)
+        ipa = parse_ipa_transcription.transcript(words=words, language=lang_alias, CONFIG["STRIP_SYLLABLE_SEPARATOR"])
     except (urllib.error.HTTPError, IndexError):
         showInfo("IPA not found.")
         return

--- a/src/anki_ipa/batch_adding.py
+++ b/src/anki_ipa/batch_adding.py
@@ -101,8 +101,8 @@ class AddIpaTranscriptDialog(qt.QDialog):
         """Get all fields of selected notes."""
         selected_note = self.selected_notes[0]
         mw = self.browser.mw
-        model = mw.col.getNote(selected_note).model()
-        fields = mw.col.models.fieldNames(model)
+        model = mw.col.get_note(selected_note).model()
+        fields = mw.col.models.field_names(model)
         return fields
 
     @qt.pyqtSlot(int)
@@ -143,7 +143,7 @@ class AddIpaTranscriptDialog(qt.QDialog):
     def _create_note_dictionary(self) -> Dict[int, anki.notes.Note]:
         """Map each note id to the corresponding Anki note object."""
         notes = {
-            note: self.browser.mw.col.getNote(note)
+            note: self.browser.mw.col.get_note(note)
             for note in self.selected_notes
         }
         return notes
@@ -160,13 +160,14 @@ class AddIpaTranscriptDialog(qt.QDialog):
         self.browser.model.beginReset()
 
         for note_id, ipa_transcription in result_dict.items():
-            note = mw.col.getNote(note_id)
+            note = mw.col.get_note(note_id)
             target_field = self.field_combobox.currentText()
             note[target_field] = ipa_transcription
             note.flush()
 
         self.browser.model.endReset()
-        mw.requireReset()
+        # mw.requireReset()
+        mw.CollectionOp()
         mw.progress.finish()
         mw.reset()
 

--- a/src/anki_ipa/config.json
+++ b/src/anki_ipa/config.json
@@ -1,5 +1,6 @@
 {
     "WORD_FIELD": "Front",
     "IPA_FIELD": "IPA",
-    "KEYBOARD_SHORTCUT": "Ctrl+Shift+Z"
+    "KEYBOARD_SHORTCUT": "Ctrl+Shift+Z",
+    "STRIP_SYLLABLE_SEPARATOR": true
 }

--- a/src/anki_ipa/config.md
+++ b/src/anki_ipa/config.md
@@ -1,0 +1,16 @@
+Help for configuration options.
+
+&nbsp;
+
+- **`"WORD_FIELD"`**: Field which contains the word or words you would like to get an IPA transcription for.
+
+&nbsp;
+
+- **`"IPA_FIELD"`**: The field name where the IPA transcription should be written into.
+&nbsp;
+
+- **`"KEYBOAD_SHORTCUT"`**: Shortcut that can be used to execute the add on.
+
+&nbsp;
+
+- **`"STRIP_SYLLABLE_SEPARATOR"`**: IPA syntax includes a period (.) between two syllables when betweem two consecutive vowels in hiatus.  For example `kre.entsa`.  By default this is stripped out but if desired it can be retained.

--- a/src/anki_ipa/config.py
+++ b/src/anki_ipa/config.py
@@ -20,5 +20,3 @@ def setup_synced_config() -> None:
             "deckdefaultlang": {},  # default addon language for specific decks
             "lang": "eng"
         }
-
-    mw.col.setMod()

--- a/src/anki_ipa/consts.py
+++ b/src/anki_ipa/consts.py
@@ -19,9 +19,7 @@ LANGUAGES_MAP = {
     'it': 'italian',
     'pt': 'portuguese',
     'zh': 'chinese',
-    'ca': 'catalan',
-    # 'mg': 'malagasy',
-    # 'ptb': 'portuguese_br',
+    'ca': 'catalan'
 }
 
 

--- a/src/anki_ipa/consts.py
+++ b/src/anki_ipa/consts.py
@@ -15,7 +15,13 @@ LANGUAGES_MAP = {
     'es': 'spanish',
     'ger': 'german',
     'pl': 'polish',
-    'nl': 'dutch'
+    'nl': 'dutch',
+    'it': 'italian',
+    'pt': 'portuguese',
+    'zh': 'chinese',
+    'ca': 'catalan',
+    # 'mg': 'malagasy',
+    # 'ptb': 'portuguese_br',
 }
 
 

--- a/src/anki_ipa/parse_ipa_transcription.py
+++ b/src/anki_ipa/parse_ipa_transcription.py
@@ -111,6 +111,30 @@ def dutch(word: str, strip_syllable_separator: bool) -> str:
     return ", ".join(parse_website(link, {"class": "IPAtekst"}, strip_syllable_separator))
 
 
+@transcription
+def italian(word: str, strip_syllable_separator: bool) -> str:
+    link = f"https://it.wiktionary.org/wiki/{word}"
+    return ", ".join(parse_website(link, {"class": "IPA"}, strip_syllable_separator))
+
+
+@transcription
+def portuguese(word: str, strip_syllable_separator: bool) -> str:
+    link = f"https://pt.wiktionary.org/wiki/{word}"
+    return ", ".join(parse_website(link, {"class": "ipa"}, strip_syllable_separator))
+
+
+@transcription
+def mandarin(word: str, strip_syllable_separator: bool) -> str:
+    link = f"https://zh.wiktionary.org/wiki/{word}"
+    return ", ".join(parse_website(link, {"class": "IPA"}, strip_syllable_separator))
+
+
+@transcription
+def catalan(word: str, strip_syllable_separator: bool) -> str:
+    link = f"https://ca.wiktionary.org/wiki/{word}"
+    return ", ".join(parse_website(link, {"class": "IPA"}, strip_syllable_separator))
+
+
 def parse_website(link: str, css_code: dict, strip_syllable_separator: bool=True) -> List[str]:
     try:
         website = requests.get(link)
@@ -131,7 +155,7 @@ def parse_website(link: str, css_code: dict, strip_syllable_separator: bool=True
             .replace("]", "")
             .replace("[", "")
             .replace("\\", ""), results)
-    _transcriptions = sorted(list(set(transcriptions)))
+    _transcriptions = sorted(list(set(transcriptions))[0])
     return _transcriptions
 
 

--- a/src/anki_ipa/parse_ipa_transcription.py
+++ b/src/anki_ipa/parse_ipa_transcription.py
@@ -82,7 +82,7 @@ def russian(word: str, strip_syllable_separator: bool) -> str:
 @transcription
 def spanish(word: str, strip_syllable_separator: bool) -> str:
     link = f"https://es.wiktionary.org/wiki/{word}"
-    return ", ".join(parse_website(link, {'style': 'color:#368BC1'}, strip_syllable_separator))
+    return ", ".join(parse_website(link, {'class': 'ipa'}, strip_syllable_separator))
 
 
 @transcription
@@ -144,5 +144,5 @@ def remove_special_chars(word: str, strip_syllable_separator: bool) -> str:
 
 def transcript(words: List[str], language: str, strip_syllable_separator: bool=True) -> str:
     transcription_method = transcription_methods[language]
-    transcribed_words = [transcription_method(word) for word in words]
+    transcribed_words = [transcription_method(word, strip_syllable_separator) for word in words]
     return " ".join(transcribed_words)

--- a/src/anki_ipa/parse_ipa_transcription.py
+++ b/src/anki_ipa/parse_ipa_transcription.py
@@ -19,7 +19,7 @@ transcription = lambda f: transcription_methods.setdefault(f.__name__, f)
 
 
 @transcription
-def british(word: str) -> str:
+def british(word: str, strip_syllable_separator: bool) -> str:
     payload = {'action': 'parse', 'page': word, 'format': 'json', 'prop': 'wikitext'}
     r = requests.get('https://en.wiktionary.org/w/api.php', params=payload)
     try:
@@ -37,12 +37,12 @@ def british(word: str) -> str:
             m = p.search(wikitext)
             
         ipa = m.group(1)
-        return remove_special_chars(word=ipa)
+        return remove_special_chars(word=ipa, strip_syllable_separator=strip_syllable_separator)
     except (KeyError, AttributeError):
         return ""
 
 @transcription
-def american(word: str) -> str:
+def american(word: str, strip_syllable_separator: bool) -> str:
     payload = {'action': 'parse', 'page': word, 'format': 'json', 'prop': 'wikitext'}
     r = requests.get('https://en.wiktionary.org/w/api.php', params=payload)
     try:
@@ -63,30 +63,30 @@ def american(word: str) -> str:
             m = p.search(wikitext)
 
         ipa = m.group(1)
-        return remove_special_chars(word=ipa)
+        return remove_special_chars(word=ipa, strip_syllable_separator=strip_syllable_separator)
     except (KeyError, AttributeError):
         return ""
 
 @transcription
-def french(word: str) -> str:
+def french(word: str, strip_syllable_separator: bool) -> str:
     link = f"https://fr.wiktionary.org/wiki/{word}"
-    return ", ".join(parse_website(link, {'title': 'Prononciation API'}))
+    return ", ".join(parse_website(link, {'title': 'Prononciation API'}, strip_syllable_separator))
 
 
 @transcription
-def russian(word: str) -> str:
+def russian(word: str, strip_syllable_separator: bool) -> str:
     link = f"https://ru.wiktionary.org/wiki/{word}"
-    return ", ".join(parse_website(link, {'class': 'IPA'}))
+    return ", ".join(parse_website(link, {'class': 'IPA'}, strip_syllable_separator))
 
 
 @transcription
-def spanish(word: str) -> str:
+def spanish(word: str, strip_syllable_separator: bool) -> str:
     link = f"https://es.wiktionary.org/wiki/{word}"
-    return ", ".join(parse_website(link, {'style': 'color:#368BC1'}))
+    return ", ".join(parse_website(link, {'style': 'color:#368BC1'}, strip_syllable_separator))
 
 
 @transcription
-def german(word: str) -> str:
+def german(word: str, strip_syllable_separator: bool) -> str:
     payload = {'action': 'parse', 'page': word, 'format': 'json', 'prop': 'wikitext'}
     r = requests.get('https://de.wiktionary.org/w/api.php', params=payload)
     try:
@@ -99,40 +99,50 @@ def german(word: str) -> str:
         return ""
 
 @transcription
-def polish(word: str) -> str:
+def polish(word: str, strip_syllable_separator: bool) -> str:
     link = f"https://pl.wiktionary.org/wiki/{word}"
     return ", ".join(parse_website(
-        link, {'title': 'To jest wymowa w zapisie IPA; zobacz hasło IPA w Wikipedii'}))
+        link, {'title': 'To jest wymowa w zapisie IPA; zobacz hasło IPA w Wikipedii'}, strip_syllable_separator))
 
 
 @transcription
-def dutch(word: str) -> str:
+def dutch(word: str, strip_syllable_separator: bool) -> str:
     link = f"https://nl.wiktionary.org/wiki/{word}"
-    return ", ".join(parse_website(link, {"class": "IPAtekst"}))
+    return ", ".join(parse_website(link, {"class": "IPAtekst"}, strip_syllable_separator))
 
 
-def parse_website(link: str, css_code: dict) -> List[str]:
+def parse_website(link: str, css_code: dict, strip_syllable_separator: bool=True) -> List[str]:
     try:
         website = requests.get(link)
     except requests.exceptions.RequestException as e:
         return [""]
     soup = bs4.BeautifulSoup(website.text, "html.parser")
     results = soup.find_all('span', css_code) 
-    transcriptions = map(lambda result: result.getText()
-        .replace("/", "")
-        .replace("]", "")
-        .replace("[", "")
-        .replace(".", "")
-        .replace("\\", ""), results)
-    return sorted(list(set(transcriptions)))
+    if strip_syllable_separator:
+        transcriptions = map(lambda result: result.getText()
+            .replace("/", "")
+            .replace("]", "")
+            .replace("[", "")
+            .replace(".", "")
+            .replace("\\", ""), results)
+    else:
+        transcriptions = map(lambda result: result.getText()
+            .replace("/", "")
+            .replace("]", "")
+            .replace("[", "")
+            .replace("\\", ""), results)
+    _transcriptions = sorted(list(set(transcriptions)))
+    return _transcriptions
 
 
-def remove_special_chars(word: str) -> str:
-   word = word.replace("/", "").replace("]", "").replace("[", "").replace(".", "").replace("\\", "").replace(".", "")
-   return word
+def remove_special_chars(word: str, strip_syllable_separator: bool) -> str:
+    word = word.replace("/", "").replace("]", "").replace("[", "").replace("\\", "").replace(".", "")
+    if strip_syllable_separator:
+        word = word.replace(".", "")
+    return word
 
 
-def transcript(words: List[str], language: str) -> str:
+def transcript(words: List[str], language: str, strip_syllable_separator: bool=True) -> str:
     transcription_method = transcription_methods[language]
     transcribed_words = [transcription_method(word) for word in words]
     return " ".join(transcribed_words)

--- a/src/anki_ipa/parse_ipa_transcription.py
+++ b/src/anki_ipa/parse_ipa_transcription.py
@@ -121,42 +121,6 @@ def portuguese(word: str, strip_syllable_separator: bool) -> str:
     return ", ".join(parse_website(link, {"class": "ipa"}, strip_syllable_separator))
 
 
-
-
-# @transcription
-# def brazilian_portuguese(word: str, strip_syllable_separator: bool) -> str:
-#     link = f"https://pt.wiktionary.org/wiki/{word}"
-#     return ", ".join(parse_website(link, {"class": "IPA"}, strip_syllable_separator))
-
-@transcription
-def mandarin(word: str, strip_syllable_separator: bool) -> str:
-    link = f"https://zh.wiktionary.org/wiki/{word}"
-    return ", ".join(parse_website(link, {"class": "IPA"}, strip_syllable_separator))
-
-# @transcription
-# def malagasy(word: str, strip_syllable_separator: bool) -> str:
-#     link = f"https://mg.wiktionary.org/wiki/{word}"
-#     return ", ".join(parse_website(link, {"class": "IPA"}, strip_syllable_separator))
-
-@transcription
-def catalan(word: str, strip_syllable_separator: bool) -> str:
-    link = f"https://ca.wiktionary.org/wiki/{word}"
-    return ", ".join(parse_website(link, {"class": "IPA"}, strip_syllable_separator))
-
-
-
-@transcription
-def italian(word: str, strip_syllable_separator: bool) -> str:
-    link = f"https://it.wiktionary.org/wiki/{word}"
-    return ", ".join(parse_website(link, {"class": "IPA"}, strip_syllable_separator))
-
-
-@transcription
-def portuguese(word: str, strip_syllable_separator: bool) -> str:
-    link = f"https://pt.wiktionary.org/wiki/{word}"
-    return ", ".join(parse_website(link, {"class": "ipa"}, strip_syllable_separator))
-
-
 @transcription
 def mandarin(word: str, strip_syllable_separator: bool) -> str:
     link = f"https://zh.wiktionary.org/wiki/{word}"


### PR DESCRIPTION
Made a few changes that might be desirable to merge into the master branch:
1. Fix for Spanish not populating properly 
2. Added a config.md with descriptions on the config options
3. Added a config option to be able to maintain the '.' in IPA.  Default is same behavior it currently is
4. Added language options: italian, portuguese, chinese (simplified), and catalan.